### PR TITLE
Split SageMakerExecPolicy into 2 separate managed policies due to policy doc size limit

### DIFF
--- a/cloudformation/ds_admin_principals.yaml
+++ b/cloudformation/ds_admin_principals.yaml
@@ -186,7 +186,6 @@ Resources:
                   - 'iam:CreatePolicy'
                   - 'iam:CreatePolicyVersion'
                   - 'iam:DeletePolicy'
-                  - 'iam:CreatePolicyVersion'
                   - 'iam:DeletePolicyVersion'
                   - 'iam:CreateRole'
                   - 'iam:DeleteRole'


### PR DESCRIPTION
*Issue #, if available:* SageMakerExecPolicy could not be deployed because it reached the managed policy document size limit

*Description of changes:* Split SageMakerExecPolicy into 2 separate managed policies - 1 for SageMaker permissions, and 1 for other services.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
