### PR TITLE
SageMakerVPCEnforcer is failing : python 3.7 is no longer supported updated to 3.12 - fix 

### DIFF
--- a/cloudformation/ds_admin_detective.yaml
+++ b/cloudformation/ds_admin_detective.yaml
@@ -63,7 +63,7 @@ Resources:
     Properties:
       FunctionName: SageMakerVPCEnforcer
       Description: Detective control to enforce VPC attachment of SageMaker resources
-      Runtime: python3.7
+      Runtime: python3.12
       Code: vpc_detective_control.zip
       Handler: inspect_sagemaker_resource.lambda_handler
       MemorySize: 320

--- a/cloudformation/ds_env_studio_user_profile_v1.yaml
+++ b/cloudformation/ds_env_studio_user_profile_v1.yaml
@@ -136,6 +136,7 @@ Resources:
               - 'sagemaker:CreateExperiment'
               - 'sagemaker:CreateModelPackage'
               - 'sagemaker:CreateModelPackageGroup'
+              - 'sagemaker:CreatePresignedDomainUrl'
               - 'sagemaker:CreateTrial'
               - 'sagemaker:CreateTrialComponent'
               - 'sagemaker:CreateApp'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

### 1. **SageMakerVPCEnforcer  Lambda function stack creation is failing.**:

Resource handler returned message: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions. 

### 2. **Update policy of user to createpresigned url**:

Policy update to support : to start Sudio classic instance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
